### PR TITLE
Update license metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
       "email": "taylor.mckinney@bazaarvoice.com"
     }
   ],
-  "license": "LicenseRef-LICENSE",
+  "license": "SEE LICENSE IN LICENSE",
   "bugs": {
     "url": "https://github.com/bazaarvoice/git-land/issues"
   },


### PR DESCRIPTION
This tiny PR anticipates an impending revision to the package.json license guidelines per npm/npm#8609

Thank you so much for taking the time to review the recently approved guidelines and tag your package appropriately. And apologies for wavering in the guidelines, for which I'm at least partially responsible.

As penance, this is just one of a few PRs I'm sending out to all the package author's who have jumped on using `LicenseRef-LICENSE`, soon to be replaced with a friendlier, less arcane "magic value" for "have a look at file X for license terms."